### PR TITLE
Remove "named" slots

### DIFF
--- a/HousingRepairsSchedulingApi.Tests/ExtensionsTests/GetSlotsResponseExtensionsTests.cs
+++ b/HousingRepairsSchedulingApi.Tests/ExtensionsTests/GetSlotsResponseExtensionsTests.cs
@@ -16,7 +16,7 @@ public class GetSlotsResponseExtensionsTests
     {
         var appointments = getSlotsResponse.ToAppointmentSlots(5, DateTime.MinValue);
 
-        appointments.Should().HaveCount(7);
+        appointments.Should().HaveCount(4);
     }
 
     [Fact]
@@ -33,9 +33,9 @@ public class GetSlotsResponseExtensionsTests
             'NonBookingDay': false,
             'Slots': [
                 {
-                    'Description': 'ALL',
+                    'Description': '08:00-10:00',
                     'StartTime': '08:00:00',
-                    'EndTime': '17:00:00',
+                    'EndTime': '10:00:00',
                     'Bookable': true,
                     'AvailableSlotCapacity': 24,
                     'MaximumSlotCapacity': 33
@@ -48,7 +48,7 @@ public class GetSlotsResponseExtensionsTests
         var appointment = getSlotsResponse.ToAppointmentSlots(5, DateTime.MinValue).First();
 
         appointment.StartTime.Should().Be(DateTime.Parse("2022-09-26T08:00:00"));
-        appointment.EndTime.Should().Be(DateTime.Parse("2022-09-26T17:00:00"));
+        appointment.EndTime.Should().Be(DateTime.Parse("2022-09-26T10:00:00"));
     }
 
     [Theory]

--- a/HousingRepairsSchedulingApi/Extensions/GetSlotsResponseExtensions.cs
+++ b/HousingRepairsSchedulingApi/Extensions/GetSlotsResponseExtensions.cs
@@ -8,12 +8,16 @@ using Dtos.Mcm;
 
 public static class GetSlotsResponseExtensions
 {
-    // remove days that are not bookable or have no slots
+    private static readonly string[] SlotDescriptions = { "ALL", "SR", "Sat AM" };
+
+    // remove days that don't match the criteria in `ShouldKeepDay`
+    // take numDaysLimit (5) days
     //
     // remove slots that are not bookable
-    // (this means looking at the bookable flag and the available slot capacity).
+    // remove slots with no availability
+    // remove slots with description in list `SlotDescriptions`
     //
-    // combine into single list
+    // Map slots into `AppointmentSlots`
     //
     // Assumptions:
     // * All time slots are going to be 2 hours long in duration. (we shouldn't have any of the Sat AM or ALL descriptions)
@@ -22,14 +26,35 @@ public static class GetSlotsResponseExtensions
     public static IEnumerable<AppointmentSlot> ToAppointmentSlots(this GetSlotsResponse response, int numDaysLimit,
         DateTime fromDate) =>
         response.SlotDays
-            .Where(day => day.NonBookingDay == false && day.ResourceCapacity > 0 && day.SlotDate >= fromDate.Date)
+            .Where(day => day.ShouldKeepDay(fromDate))
             .Take(numDaysLimit)
             .SelectMany(day =>
                 {
                     var date = day.SlotDate;
 
-                    return day.Slots.Where(slot => slot.AvailableSlotCapacity > 0 && slot.Bookable).Select(slot =>
-                        new AppointmentSlot(date.Add(slot.StartTime), date.Add(slot.EndTime)));
+                    return day.Slots
+                        .Where(slot =>
+                            slot.AvailableSlotCapacity > 0 && slot.Bookable &&
+                            !SlotDescriptions.Contains(slot.Description)).Select(slot =>
+                            new AppointmentSlot(date.Add(slot.StartTime), date.Add(slot.EndTime)));
                 }
             );
+
+    private static bool HasTwoHourTimeSlot(this SlotDay day) =>
+        day.Slots.Any(slot => !SlotDescriptions.Contains(slot.Description));
+
+    private static bool ShouldKeepDay(this SlotDay day, DateTime fromDate)
+    {
+        if (day.NonBookingDay || day.ResourceCapacity == 0 || day.SlotDate < fromDate.Date)
+        {
+            return false;
+        }
+
+        // Should keep day if it has at least one slot that matches all of the following criteria:
+        // * Slot is bookable
+        // * Slot has an available capacity > 0
+        // * Slot must have a description such as 10:00-12:00 that is not in the list {"ALL", "Sat AM", "SR"}
+        return day.Slots.Any(slot =>
+            slot.Bookable && slot.AvailableSlotCapacity > 0 && !SlotDescriptions.Contains(slot.Description));
+    }
 }


### PR DESCRIPTION
We are removing slots such as "Sat AM" and "ALL" from the list of available slots shown to the user. This may not be necessary in production as these slots _should_ not be returned from MCM, but we don't necessarily want to rely on this behaviour as it is not something that we control.